### PR TITLE
Fix breathing cycle orientation

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,27 +30,31 @@ function update(timestamp) {
     lastTimestamp = timestamp;
     elapsedTotal += delta;
 
-    const cycleTime = secondsPerSide * 4;
-    const elapsed = elapsedTotal % cycleTime;
-    const t = elapsed / secondsPerSide; // 0-4
+    const phase = Math.floor(elapsedTotal / secondsPerSide) % 4;
+    const progress = (elapsedTotal % secondsPerSide) / secondsPerSide;
 
     let x, y;
-    if (t < 1) { // top: left -> right (breathe in)
-        x = margin + size * t;
-        y = margin;
-        instructionEl.textContent = 'Breathe in';
-    } else if (t < 2) { // right: top -> bottom (hold)
-        x = margin + size;
-        y = margin + size * (t - 1);
-        instructionEl.textContent = 'Hold';
-    } else if (t < 3) { // bottom: right -> left (breathe out)
-        x = margin + size * (3 - t);
-        y = margin + size;
-        instructionEl.textContent = 'Breathe out';
-    } else { // left: bottom -> top (hold)
-        x = margin;
-        y = margin + size * (4 - t);
-        instructionEl.textContent = 'Hold';
+    switch (phase) {
+        case 0: // bottom left -> top left (breathe in)
+            x = margin;
+            y = margin + size * (1 - progress);
+            instructionEl.textContent = 'Breathe in';
+            break;
+        case 1: // top left -> top right (hold)
+            x = margin + size * progress;
+            y = margin;
+            instructionEl.textContent = 'Hold';
+            break;
+        case 2: // top right -> bottom right (breathe out)
+            x = margin + size;
+            y = margin + size * progress;
+            instructionEl.textContent = 'Breathe out';
+            break;
+        default: // bottom right -> bottom left (hold)
+            x = margin + size * (1 - progress);
+            y = margin + size;
+            instructionEl.textContent = 'Hold';
+            break;
     }
 
     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -62,6 +66,10 @@ function update(timestamp) {
 range.addEventListener('input', () => {
     secondsPerSide = parseInt(range.value, 10);
     speedValue.textContent = secondsPerSide;
+    // restart cycle at the beginning of "Breathe in"
+    elapsedTotal = 0;
+    lastTimestamp = null;
+    instructionEl.textContent = 'Breathe in';
 });
 
 speedValue.textContent = secondsPerSide;


### PR DESCRIPTION
## Summary
- revise `update` logic to use explicit phase + progress calculation
- start the cycle at the inhale phase when the slider value changes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68487d3576cc832eb6263ff2a709f372