### PR TITLE
Fix double box by removing canvas border

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,7 +16,6 @@ body {
 
 canvas {
     background-color: #000;
-    border: 2px solid #fff;
 }
 
 .slider-container {


### PR DESCRIPTION
## Summary
- remove canvas CSS border to avoid nested box illusion

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684881538558832e8fd2ee1cb99859a9