### PR TITLE
Add page timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # BoxBreathing
 
-A simple black and white box breathing web app. Open `index.html` or host the contents on GitHub Pages.
+A simple black and white box breathing web app. Open `index.html` or host the
+contents on GitHub Pages. The page shows an elapsed time counter that starts
+when the page loads and resets on refresh.

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <div id="app">
         <canvas id="canvas" width="300" height="300"></canvas>
         <p id="instruction">Breathe in</p>
+        <p id="timer">0s</p>
         <div class="slider-container">
             <label for="speedRange">Seconds per side: <span id="speedValue">4</span></label>
             <input type="range" id="speedRange" min="3" max="8" value="4">

--- a/script.js
+++ b/script.js
@@ -3,10 +3,12 @@ const ctx = canvas.getContext('2d');
 const instructionEl = document.getElementById('instruction');
 const range = document.getElementById('speedRange');
 const speedValue = document.getElementById('speedValue');
+const timerEl = document.getElementById('timer');
 
 let secondsPerSide = parseInt(range.value, 10);
 let lastTimestamp = null;
 let elapsedTotal = 0;
+let startTime = null;
 
 const size = 200; // square size
 const margin = 50; // offset from canvas edges
@@ -25,10 +27,13 @@ function drawSquare() {
 }
 
 function update(timestamp) {
+    if (!startTime) startTime = timestamp;
     if (!lastTimestamp) lastTimestamp = timestamp;
     const delta = (timestamp - lastTimestamp) / 1000;
     lastTimestamp = timestamp;
     elapsedTotal += delta;
+    const elapsedTimer = (timestamp - startTime) / 1000;
+    timerEl.textContent = `${elapsedTimer.toFixed(1)}s`;
 
     const phase = Math.floor(elapsedTotal / secondsPerSide) % 4;
     const progress = (elapsedTotal % secondsPerSide) / secondsPerSide;

--- a/style.css
+++ b/style.css
@@ -18,6 +18,10 @@ canvas {
     background-color: #000;
 }
 
+#timer {
+    margin-top: 10px;
+}
+
 .slider-container {
     margin-top: 20px;
 }


### PR DESCRIPTION
## Summary
- show an elapsed time counter that resets on refresh
- style the timer
- document timer in the README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686aa0eeedfc832e9fb1cb0f0b010496