### PR TITLE
Adjust timer placement and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # BoxBreathing
 
 A simple black and white box breathing web app. Open `index.html` or host the
-contents on GitHub Pages. The page shows an elapsed time counter that starts
-when the page loads and resets on refresh.
+contents on GitHub Pages. The page shows an elapsed time counter in the top
+right that starts when the page loads and resets on refresh.

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
 </head>
 <body>
     <h1>Box Breathing</h1>
+    <p id="timer">0:00</p>
     <div id="app">
         <canvas id="canvas" width="300" height="300"></canvas>
         <p id="instruction">Breathe in</p>
-        <p id="timer">0s</p>
         <div class="slider-container">
             <label for="speedRange">Seconds per side: <span id="speedValue">4</span></label>
             <input type="range" id="speedRange" min="3" max="8" value="4">

--- a/script.js
+++ b/script.js
@@ -33,7 +33,10 @@ function update(timestamp) {
     lastTimestamp = timestamp;
     elapsedTotal += delta;
     const elapsedTimer = (timestamp - startTime) / 1000;
-    timerEl.textContent = `${elapsedTimer.toFixed(1)}s`;
+    const totalSeconds = Math.floor(elapsedTimer);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    timerEl.textContent = `${minutes}:${seconds.toString().padStart(2, '0')}`;
 
     const phase = Math.floor(elapsedTotal / secondsPerSide) % 4;
     const progress = (elapsedTotal % secondsPerSide) / secondsPerSide;

--- a/style.css
+++ b/style.css
@@ -19,7 +19,9 @@ canvas {
 }
 
 #timer {
-    margin-top: 10px;
+    position: absolute;
+    top: 10px;
+    right: 10px;
 }
 
 .slider-container {


### PR DESCRIPTION
## Summary
- move timer element outside the breathing box
- style the timer so it sits in the page's top right corner
- display elapsed time as minutes and seconds
- document new timer position

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686aa2c7f458832ea1ef23bf0f074828