### PR TITLE
Add Supabase save/load feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Box Breathing</title>
-    <link rel="stylesheet" href="style.css">
-</head>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Box Breathing</title>
+        <link rel="stylesheet" href="style.css">
+        <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+    </head>
 <body>
     <h1>Box Breathing</h1>
     <p id="timer">0:00</p>
@@ -16,6 +17,8 @@
             <label for="speedRange">Seconds per side: <span id="speedValue">4</span></label>
             <input type="range" id="speedRange" min="3" max="8" value="4">
         </div>
+        <button id="saveBtn">Save</button>
+        <button id="loadBtn">Load</button>
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,12 @@ const instructionEl = document.getElementById('instruction');
 const range = document.getElementById('speedRange');
 const speedValue = document.getElementById('speedValue');
 const timerEl = document.getElementById('timer');
+const saveBtn = document.getElementById('saveBtn');
+const loadBtn = document.getElementById('loadBtn');
+
+const supabaseUrl = 'https://kakhtozhcphemmmyclmz.supabase.co';
+const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtha2h0b3poY3BoZW1tbXljbG16Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAzNTQ5MzksImV4cCI6MjA2NTkzMDkzOX0.Oe8GPcFpUWeDH1CG2lN2TQ8F4m4uVqq15jlhw4f-R0g';
+const supabase = supabase.createClient(supabaseUrl, supabaseKey);
 
 let secondsPerSide = parseInt(range.value, 10);
 let lastTimestamp = null;
@@ -80,5 +86,28 @@ range.addEventListener('input', () => {
 });
 
 speedValue.textContent = secondsPerSide;
+
+saveBtn.addEventListener('click', async () => {
+    await supabase.from('sessions').insert({
+        seconds_per_side: secondsPerSide,
+        elapsed_total: elapsedTotal
+    });
+});
+
+loadBtn.addEventListener('click', async () => {
+    const { data } = await supabase
+        .from('sessions')
+        .select('*')
+        .order('id', { ascending: false })
+        .limit(1)
+        .single();
+    if (data) {
+        secondsPerSide = data.seconds_per_side;
+        elapsedTotal = data.elapsed_total;
+        range.value = secondsPerSide;
+        speedValue.textContent = secondsPerSide;
+    }
+});
+
 requestAnimationFrame(update);
 


### PR DESCRIPTION
## Summary
- add Supabase script and Save/Load buttons
- save breathing settings and timer to Supabase
- load the latest saved values from Supabase

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687555e28bb0832ebfd96899fb33a3c9